### PR TITLE
Added two chaos monkey types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ target/
 .checkstyle-cachefile
 .DS_Store
 dependency-reduced-pom.xml
+tmp/

--- a/uba-service/src/main/java/com/jivesoftware/os/upena/uba/service/ClusterServiceInstance.java
+++ b/uba-service/src/main/java/com/jivesoftware/os/upena/uba/service/ClusterServiceInstance.java
@@ -29,27 +29,24 @@ public class ClusterServiceInstance implements Comparable<ClusterServiceInstance
 
     @Override
     public int compareTo(ClusterServiceInstance other) {
-        if (other == null) {
-            return -1;
-        }
         int c = this.hostName.compareTo(other.hostName);
-        if (c < 0) {
+        if (c != 0) {
             return c;
         }
         c = this.serviceName.compareTo(other.serviceName);
-        if (c < 0) {
+        if (c != 0) {
             return c;
         }
         c = this.instanceName.compareTo(other.instanceName);
-        if (c < 0) {
+        if (c != 0) {
             return c;
         }
         c = new Integer(port).compareTo(other.port);
-        if (c < 0) {
+        if (c != 0) {
             return c;
         }
         c = new Integer(jmxPort).compareTo(other.jmxPort);
-        if (c < 0) {
+        if (c != 0) {
             return c;
         }
         c = new Integer(debuggingPort).compareTo(other.debuggingPort);

--- a/uba-service/src/main/java/com/jivesoftware/os/upena/uba/service/NannyStatusCallable.java
+++ b/uba-service/src/main/java/com/jivesoftware/os/upena/uba/service/NannyStatusCallable.java
@@ -130,7 +130,7 @@ class NannyStatusCallable implements Callable<Boolean> {
             }
             int checks = 1;
             while (checks < 10) { // todo expose to config or to instance
-                healthLog.forcedHealthState("Service Startup", "Service is being verifyed. Phase: verify...", "Be patient");
+                healthLog.forcedHealthState("Service Startup", "Service is being verified. Phase: verify...", "Be patient");
                 status.set("Verfying" + checks);
                 if (invokeScript.invoke(deployLog, instancePath, "status")) {
                     deployLog.log("Service:" + instancePath.toHumanReadableName() + " 'status'", "ONLINE", null);

--- a/upena-amza/src/main/java/com/jivesoftware/os/amza/service/discovery/AmzaDiscovery.java
+++ b/upena-amza/src/main/java/com/jivesoftware/os/amza/service/discovery/AmzaDiscovery.java
@@ -73,7 +73,7 @@ public class AmzaDiscovery {
                             String received = new String(packet.getData(), 0, packet.getLength());
                             String[] clusterHostPort = received.split(":");
                             if (clusterHostPort.length == 3 && clusterHostPort[0] != null && clusterHostPort[0].equals(clusterName)) {
-                                LOG.debug("recieved:" + Arrays.toString(clusterHostPort));
+                                LOG.debug("received:" + Arrays.toString(clusterHostPort));
                                 String host = clusterHostPort[1];
                                 int port = Integer.parseInt(clusterHostPort[2].trim());
                                 RingHost anotherRingHost = new RingHost(host, port); // TODO need to broadcast rack id

--- a/upena-deployable/src/main/java/com/jivesoftware/os/upena/deployable/UpenaMain.java
+++ b/upena-deployable/src/main/java/com/jivesoftware/os/upena/deployable/UpenaMain.java
@@ -174,7 +174,6 @@ public class UpenaMain {
                 System.out.println("java -jar upena.jar " + InetAddress.getLocalHost().getHostName() + " dev");
                 System.out.println("");
                 System.exit(1);
-
             } else {
                 new UpenaMain().run(args);
             }
@@ -198,7 +197,7 @@ public class UpenaMain {
                 break;
             } catch (Exception x) {
                 failed = x;
-                System.out.println("Failed to aquire lock on onlyLetOneRunningAtATime");
+                System.out.println("Failed to acquire lock on onlyLetOneRunningAtATime");
                 Thread.sleep(1000);
             }
         }
@@ -213,10 +212,8 @@ public class UpenaMain {
             LOG.warn("Failed to local tools.jar. Please manually add to classpath. Breakpoint debugger will be disabled.");
         }
 
-        String hostname = InetAddress.getLocalHost().getHostName();
-        if (args != null && args.length > 0) {
-            hostname = args[0];
-        }
+        String hostname = args[0];
+
         int port = Integer.parseInt(System.getProperty("amza.port", "1175"));
         String multicastGroup = System.getProperty("amza.discovery.group", "225.4.5.6");
         int multicastPort = Integer.parseInt(System.getProperty("amza.discovery.port", "1123"));

--- a/upena-deployable/src/main/java/com/jivesoftware/os/upena/deployable/UpenaPropagatorEndpoints.java
+++ b/upena-deployable/src/main/java/com/jivesoftware/os/upena/deployable/UpenaPropagatorEndpoints.java
@@ -38,8 +38,6 @@ import javax.ws.rs.core.StreamingOutput;
 @Path("/propagator")
 public class UpenaPropagatorEndpoints {
 
-    private static final MetricLogger LOG = MetricLoggerFactory.getLogger();
-
     @GET
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
     @Path("/download")

--- a/upena-deployable/src/main/java/com/jivesoftware/os/upena/deployable/endpoints/AsyncLookupEndpoints.java
+++ b/upena-deployable/src/main/java/com/jivesoftware/os/upena/deployable/endpoints/AsyncLookupEndpoints.java
@@ -164,10 +164,10 @@ public class AsyncLookupEndpoints {
         try {
             List<Map<String, String>> results = Lists.newArrayList();
             for (ChaosStrategyKey s: ChaosStrategyKey.values()){
-                results.add(ImmutableMap.of("key", s.key, "name", s.name));
+                results.add(ImmutableMap.of("key", s.name(), "name", s.description));
             }
 
-            Collections.sort(results, (Map<String, String> o1, Map<String, String> o2) -> {
+            results.sort((Map<String, String> o1, Map<String, String> o2) -> {
                 int c = o1.get("name").compareTo(o2.get("name"));
                 if (c != 0) {
                     return c;

--- a/upena-deployable/src/main/resources/resources/soy/homeRegion.soy
+++ b/upena-deployable/src/main/resources/resources/soy/homeRegion.soy
@@ -13,10 +13,10 @@
             
             <div class="panel-body">
                 Expand this cluster by running the following on a new node:<br><br>
-                wget -O upena.jar {$wgetURL} <br>
+                wget -O upena.jar {$wgetURL}<br>
 
                 Basic:<br>
-                nohup java -jar upena.jar `hostname` {$upenaClusterName} &
+                nohup java -jar upena.jar `hostname` {$upenaClusterName} &amp;
 
                 Advanced:<br>
                 nohup java -Dhost.datacenter=<datacenterName> -Dhost.rack=<rackName/availability zone> -classpath "/usr/java/latest/lib/tools.jar:./upena.jar" com.jivesoftware.os.upena.deployable.UpenaMain <hostname> <clusterName>

--- a/upena-service/src/main/java/com/jivesoftware/os/upena/service/MonkeyKeyProvider.java
+++ b/upena-service/src/main/java/com/jivesoftware/os/upena/service/MonkeyKeyProvider.java
@@ -27,7 +27,7 @@ public class MonkeyKeyProvider implements UpenaTable.UpenaKeyProvider<MonkeyKey,
 
     @Override
     public MonkeyKey getNodeKey(UpenaTable<MonkeyKey, Monkey> table, Monkey value) {
-        String compositeKey = value.clusterKey + "|" + value.hostKey + "|" + value.serviceKey + "|" + value.strategyKey.key;
+        String compositeKey = value.clusterKey + "|" + value.hostKey + "|" + value.serviceKey + "|" + value.strategyKey;
         String k = Long.toString(Math.abs(jenkinsHash.hash(compositeKey.getBytes(UTF8), 5)));
         return new MonkeyKey(k);
     }

--- a/upena-service/src/main/java/com/jivesoftware/os/upena/service/UpenaService.java
+++ b/upena-service/src/main/java/com/jivesoftware/os/upena/service/UpenaService.java
@@ -135,10 +135,18 @@ public class UpenaService {
             return failedConnectionResponse(connectionsRequest, "No declared instance for: " + connectionsRequest);
         }
 
-        String monkeyAffect = chaosService.monkeyAffect(instance);
-        if (!monkeyAffect.isEmpty()) {
-            primaryConnections = chaosService.unleashMonkey(instance, primaryConnections);
-            messages.add("Monkey affect: [" + monkeyAffect + "]");
+        // handle instance and service monkeys
+        for (HostKey hk : Arrays.asList(instance.hostKey, new HostKey(""))) {
+            String monkeyAffectInstances = chaosService.monkeyAffect(instance.clusterKey, hk, instance.serviceKey);
+            if (!monkeyAffectInstances.isEmpty()) {
+                primaryConnections = chaosService.unleashMonkey(
+                        instance.clusterKey,
+                        hk,
+                        instance.serviceKey,
+                        instance.instanceId,
+                        primaryConnections);
+                messages.add("Monkey affect: [" + monkeyAffectInstances + "]");
+            }
         }
 
         messages.add("Success");

--- a/upena-service/src/main/java/com/jivesoftware/os/upena/service/UpenaTable.java
+++ b/upena-service/src/main/java/com/jivesoftware/os/upena/service/UpenaTable.java
@@ -34,12 +34,10 @@ public class UpenaTable<K extends Key, V extends Stored> {
     private static final MetricLogger LOG = MetricLoggerFactory.getLogger();
 
     static public interface UpenaKeyProvider<KK extends Key, VV extends Stored> {
-
         KK getNodeKey(UpenaTable<KK, VV> table, VV value);
     }
 
     static public interface UpenaValueValidator<KK extends Key, VV extends Stored> {
-
         VV validate(UpenaTable<KK, VV> table, KK key, VV value) throws Exception;
     }
 
@@ -85,12 +83,11 @@ public class UpenaTable<K extends Key, V extends Stored> {
     }
 
     public interface Stream<K, V> {
-
         boolean stream(K key, V value) throws Exception;
     }
 
+    @SuppressWarnings("unchecked")
     public ConcurrentNavigableMap<K, TimestampedValue<V>> find(final KeyValueFilter<K, V> filter) throws Exception {
-
         final ConcurrentNavigableMap<K, TimestampedValue<V>> results = filter.createCollector();
         List<RowIndexKey> badKeys = Lists.newArrayList();
         store.scan((transactionId, key, value) -> {

--- a/upena-shared/src/main/java/com/jivesoftware/os/upena/shared/ChaosStrategyKey.java
+++ b/upena-shared/src/main/java/com/jivesoftware/os/upena/shared/ChaosStrategyKey.java
@@ -22,46 +22,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public enum ChaosStrategyKey {
 
-    RANDOMIZE_PORT("1", "Randomize port"),
-    RANDOMIZE_HOSTNAME("2", "Randomize host name");
+    RANDOMIZE_PORT("Randomize port"),
+    RANDOMIZE_HOSTNAME("Randomize host name"),
+    SPLIT_BRAIN("Split-brain"),
+    RANDOM_CONNECTION_LATENCY("Random connection latency");
 
-    public final String key;
-    public final String name;
+    public final String description;
 
     @JsonCreator
-    ChaosStrategyKey(@JsonProperty("key") String key,
-                     @JsonProperty("name") String name) {
-        this.key = key;
-        this.name = name;
+    ChaosStrategyKey(@JsonProperty("description") String description) {
+        this.description = description;
     }
 
-    public static boolean isValid(String key) {
-        if (key == null || key.isEmpty())
-            return false;
-
-        for (ChaosStrategyKey v : values()) {
-            if (v.key.equals(key)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    public static ChaosStrategyKey valueOfKey(String key) {
-        for (ChaosStrategyKey v : values()) {
-            if (v.key.equals(key)) {
-                return v;
-            }
-        }
-        throw new IllegalArgumentException("No enum const " + ChaosStrategyKey.class + "@key." + key);
-    }
-
-    @Override
-    public String toString() {
-        return "ChaosStrategyKey{" +
-                "key=" + key +
-                ", name='" + name + '\'' +
-                '}';
-    }
 }

--- a/upena-shared/src/main/java/com/jivesoftware/os/upena/shared/Monkey.java
+++ b/upena-shared/src/main/java/com/jivesoftware/os/upena/shared/Monkey.java
@@ -17,7 +17,6 @@ package com.jivesoftware.os.upena.shared;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.io.Serializable;


### PR DESCRIPTION
* split-brain - returns only half of the cluster routing table to each instance for a given service
* random latency - instructs the upena client to use the latent http client
* minor code hygiene